### PR TITLE
Octavia driver to honor Octavia API status codes

### DIFF
--- a/neutron_lbaas/common/exceptions.py
+++ b/neutron_lbaas/common/exceptions.py
@@ -49,3 +49,27 @@ class MisMatchedKey(TLSException):
 
 class CertificateStorageException(TLSException):
     message = _LE('Could not store certificate: %(msg)s')
+
+
+class BadRequestException(exceptions.BadRequest):
+    message = "%(fault_string)s"
+
+
+class ConflictException(exceptions.Conflict):
+    message = "%(fault_string)s"
+
+
+class NotAuthorizedException(exceptions.NotAuthorized):
+    message = "%(fault_string)s"
+
+
+class NotFoundException(exceptions.NotFound):
+    message = "%(fault_string)s"
+
+
+class ServiceUnavailableException(exceptions.ServiceUnavailable):
+    message = "%(fault_string)s"
+
+
+class UnknownException(exceptions.NeutronException):
+    message = "%(fault_string)s"

--- a/neutron_lbaas/drivers/octavia/driver.py
+++ b/neutron_lbaas/drivers/octavia/driver.py
@@ -25,6 +25,7 @@ from oslo_utils import excutils
 import requests
 
 from neutron_lbaas._i18n import _
+from neutron_lbaas.common import exceptions
 from neutron_lbaas.common import keystone
 from neutron_lbaas.drivers import driver_base
 from neutron_lbaas.drivers.octavia import octavia_messaging_consumer
@@ -143,6 +144,27 @@ class OctaviaRequest(object):
         LOG.debug("Octavia Response Code: {0}".format(r.status_code))
         LOG.debug("Octavia Response Body: {0}".format(r.content))
         LOG.debug("Octavia Response Headers: {0}".format(r.headers))
+        # We need to raise Octavia errors up to neutron API.
+        try:
+            fault_string = jsonutils.loads(r.content)['faultstring']
+        except Exception:
+            fault_string = "Unknown Octavia error."
+        if r.status_code == 400:
+            raise exceptions.BadRequestException(fault_string=fault_string)
+        elif r.status_code == 401:
+            raise exceptions.NotAuthorizedException(fault_string=fault_string)
+        elif r.status_code == 403:
+            raise exceptions.NotAuthorizedException(fault_string=fault_string)
+        elif r.status_code == 404:
+            raise exceptions.NotFoundException(fault_string=fault_string)
+        elif r.status_code == 409:
+            raise exceptions.ConflictException(fault_string=fault_string)
+        elif r.status_code == 500:
+            raise exceptions.UnknownException(fault_string=fault_string)
+        elif r.status_code == 503:
+            raise exceptions.ServiceUnavailableException(
+                fault_string=fault_string)
+
         if method != 'DELETE':
             return r.json()
 

--- a/neutron_lbaas/services/loadbalancer/plugin.py
+++ b/neutron_lbaas/services/loadbalancer/plugin.py
@@ -34,6 +34,7 @@ from oslo_utils import encodeutils
 from neutron_lbaas._i18n import _LI, _LE
 from neutron_lbaas import agent_scheduler as agent_scheduler_v2
 import neutron_lbaas.common.cert_manager
+from neutron_lbaas.common import exceptions
 from neutron_lbaas.common.tls_utils import cert_parser
 from neutron_lbaas.db.loadbalancer import loadbalancer_dbv2 as ldbv2
 from neutron_lbaas.db.loadbalancer import models
@@ -167,6 +168,13 @@ class LoadBalancerPluginv2(loadbalancerv2.LoadBalancerPluginBaseV2):
         except (lbaas_agentschedulerv2.NoEligibleLbaasAgent,
                 lbaas_agentschedulerv2.NoActiveLbaasAgent) as no_agent:
             raise no_agent
+        # Pass these exceptions through to neutron
+        except (exceptions.ConflictException,
+                exceptions.NotFoundException,
+                exceptions.NotAuthorizedException,
+                exceptions.BadRequestException,
+                exceptions.ServiceUnavailableException):
+            raise
         except Exception as e:
             LOG.exception(_LE("There was an error in the driver"))
             self._handle_driver_error(context, db_entity)

--- a/tools/tox_install.sh
+++ b/tools/tox_install.sh
@@ -14,7 +14,7 @@
 # pip install {opts} {packages}
 
 ZUUL_CLONER=/usr/zuul-env/bin/zuul-cloner
-BRANCH_NAME=stable/newton
+BRANCH_NAME=newton-eol
 neutron_installed=$(echo "import neutron" | python 2>/dev/null ; echo $?)
 NEUTRON_DIR=$HOME/neutron
 


### PR DESCRIPTION
Currently the Octavia driver for neutron-lbaas is not honoring Octavia API
status codes. This can lead to a race condition where the status update
thread is behind the actual object status in Octavia.
This updates the driver to raise the appropriate status code to the
neutron API.

Story: 2001257
Task: 5787
(cherry picked from commit cfea70bdc4b759e31ef6a87cdaf79b9d1baea572)